### PR TITLE
fix(release-qa): point the run-bundle matrix at the renamed v2 test

### DIFF
--- a/scripts/release-qa/run-bundle-contract-matrix.mjs
+++ b/scripts/release-qa/run-bundle-contract-matrix.mjs
@@ -28,7 +28,7 @@ export const UNCHAIN_RUN_BUNDLE_TESTS = Object.freeze([
   "tests/test_run_bundle_ledger_runtime.py::test_compact_projection_rejects_present_null_extension_on_replay",
   "tests/test_run_bundle_ledger_runtime.py::test_compact_projection_details_digest_is_bound_to_bundle_extension",
   "tests/test_run_bundle_ledger_runtime.py::test_compact_projection_reuses_final_revision_details_row_and_never_conflicts",
-  "tests/test_run_bundle_ledger_runtime.py::test_materialize_fails_when_metric_event_compaction_still_exceeds_v1_limit",
+  "tests/test_run_bundle_ledger_runtime.py::test_materialize_switches_to_v2_when_compaction_still_exceeds_v1_limit",
   "tests/test_run_bundle_ledger_runtime.py::test_compact_projection_requires_durable_projection_details",
   "tests/test_run_bundle_ledger_runtime.py::test_persist_bundle_with_projection_details_is_atomic_on_projection_conflict",
   "tests/test_run_bundle_ledger_runtime.py::test_projection_details_accept_more_than_legacy_receipt_query_limit",


### PR DESCRIPTION
## What

The RunBundle v1 boundary contract gate fails on **every** branch with:

```
ERROR: not found: tests/test_run_bundle_ledger_runtime.py::test_materialize_fails_when_metric_event_compaction_still_exceeds_v1_limit
[run-bundle-contract] Unchain canonical producer and ledger failed
```

The matrix names a test unchain no longer has. When v2 schema support landed (8d893d4a), that scenario stopped *failing* and started producing a v2 bundle, so unchain renamed the test to match. The reference here was left on the old name — and pytest treats an unknown node id as an **error**, not a skip, so the gate breaks regardless of what the branch under test changed.

## The rename

| | |
|---|---|
| matrix referenced | `test_materialize_**fails**_when_metric_event_compaction_still_exceeds_v1_limit` |
| unchain has | `test_materialize_**switches_to_v2**_when_compaction_still_exceeds_v1_limit` |

Same file, same scenario: monkeypatches `_MAX_CANONICAL_BYTES` to 4096, drives 20 receipts and 40 metric events past the v1 ceiling, and asserts `schema == "unchain.run_bundle.v2"`. It is the successor to the assertion the old name described, not a different test.

## Verification

All **54** `UNCHAIN_RUN_BUNDLE_TESTS` node ids now resolve against the unchain checkout — this was the only unresolved one. Checked by parsing the matrix and matching each `::name` against a `def`/`class` in the referenced file.

## Why it is its own PR

Found while merging dev into #193 (z-index scale). Keeping it separate so the layering PR does not carry an unrelated CI fix, and so this can unblock other branches on its own.