### PR TITLE
fix: canonicalize Windows signing evidence

### DIFF
--- a/.github/actions/windows-artifact-signing/action.yml
+++ b/.github/actions/windows-artifact-signing/action.yml
@@ -358,4 +358,9 @@ runs:
           }
         }
         $report | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $env:EVIDENCE_OUTPUT -Encoding utf8
+        node scripts/release-qa/canonicalize-windows-signing-evidence.mjs `
+          --evidence "$env:EVIDENCE_OUTPUT"
+        if ($LASTEXITCODE -ne 0) {
+          throw "Windows signing evidence canonicalization failed"
+        }
         "evidence_path=$([System.IO.Path]::GetFullPath($env:EVIDENCE_OUTPUT))" >> $env:GITHUB_OUTPUT

--- a/scripts/release-qa/canonicalize-windows-signing-evidence.mjs
+++ b/scripts/release-qa/canonicalize-windows-signing-evidence.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SUPPORTED_SCHEMAS = new Set([
+  "pupu.windows-release-candidate-signing.v1",
+  "pupu.windows-signing-qualification.v1",
+]);
+
+const UTF8_COMPARE = (left, right) => Buffer.compare(
+  Buffer.from(left, "utf8"),
+  Buffer.from(right, "utf8"),
+);
+
+const canonicalizeEntries = (items, label) => {
+  if (!Array.isArray(items)) {
+    throw new Error(`${label} must be an array`);
+  }
+  const paths = items.map((item, index) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new Error(`${label}[${index}] must be an object`);
+    }
+    if (
+      typeof item.path !== "string" ||
+      !item.path ||
+      item.path !== item.path.trim()
+    ) {
+      throw new Error(`${label}[${index}].path must be a non-empty string`);
+    }
+    return item.path;
+  });
+  if (new Set(paths).size !== paths.length) {
+    throw new Error(`${label} paths must be unique`);
+  }
+  return [...items].sort((left, right) => UTF8_COMPARE(left.path, right.path));
+};
+
+export function canonicalizeWindowsSigningEvidence(evidence) {
+  if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) {
+    throw new Error("Windows signing evidence must be an object");
+  }
+  if (!SUPPORTED_SCHEMAS.has(evidence.schema)) {
+    throw new Error(
+      `unsupported Windows signing evidence schema: ${evidence.schema || "(missing)"}`,
+    );
+  }
+  return {
+    ...evidence,
+    unsigned_payload_exceptions: canonicalizeEntries(
+      evidence.unsigned_payload_exceptions,
+      "Windows signing evidence unsigned_payload_exceptions",
+    ),
+    signed_files: canonicalizeEntries(
+      evidence.signed_files,
+      "Windows signing evidence signed_files",
+    ),
+  };
+}
+
+export function canonicalizeWindowsSigningEvidenceFile(evidencePath) {
+  if (typeof evidencePath !== "string" || !evidencePath.trim()) {
+    throw new Error("evidence path is required");
+  }
+  const resolvedPath = path.resolve(evidencePath);
+  if (!fs.statSync(resolvedPath, { throwIfNoEntry: false })?.isFile()) {
+    throw new Error(`Windows signing evidence is missing: ${resolvedPath}`);
+  }
+  let evidence;
+  try {
+    evidence = JSON.parse(fs.readFileSync(resolvedPath, "utf8"));
+  } catch (error) {
+    throw new Error(`unable to read Windows signing evidence: ${error.message}`);
+  }
+  const canonical = canonicalizeWindowsSigningEvidence(evidence);
+  fs.writeFileSync(resolvedPath, `${JSON.stringify(canonical, null, 2)}\n`, "utf8");
+  return canonical;
+}
+
+const parseArgs = (argv) => {
+  if (argv.length !== 2 || argv[0] !== "--evidence" || !argv[1]) {
+    throw new Error(
+      "usage: canonicalize-windows-signing-evidence.mjs --evidence <path>",
+    );
+  }
+  return { evidencePath: argv[1] };
+};
+
+const modulePath = path.resolve(import.meta.filename);
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  try {
+    const { evidencePath } = parseArgs(process.argv.slice(2));
+    const canonical = canonicalizeWindowsSigningEvidenceFile(evidencePath);
+    console.log(
+      `[windows-signing-evidence] canonicalized ${canonical.signed_files.length} signed paths`,
+    );
+  } catch (error) {
+    console.error(`[windows-signing-evidence] ${error.message || String(error)}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/release-qa/canonicalize-windows-signing-evidence.test.mjs
+++ b/scripts/release-qa/canonicalize-windows-signing-evidence.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  canonicalizeWindowsSigningEvidence,
+} from "./canonicalize-windows-signing-evidence.mjs";
+
+const signature = {
+  sha256: "a".repeat(64),
+  signer_subject: "CN=PuPu release signing test",
+  signer_thumbprint: "ABCDEF0123456789ABCDEF0123456789ABCDEF01",
+};
+
+const signedFile = (path) => ({ path, ...signature });
+const windowsPath = (...segments) => segments.join(String.fromCharCode(92));
+const CLI = path.resolve(
+  import.meta.dirname,
+  "canonicalize-windows-signing-evidence.mjs",
+);
+
+const evidence = (overrides = {}) => ({
+  schema: "pupu.windows-release-candidate-signing.v1",
+  unsigned_payload_exceptions: [
+    {
+      path: windowsPath("resources", "mcp_runtime", "python", "DLLs", "tk86t.dll"),
+    },
+    {
+      path: windowsPath("resources", "mcp_runtime", "python", "DLLs", "tcl86t.dll"),
+    },
+  ],
+  signed_files: [
+    signedFile(windowsPath(".release-qa", "windows-unpacked", "d3dcompiler_47.dll")),
+    signedFile(windowsPath(".release-qa", "windows-unpacked", "libGLESv2.dll")),
+    signedFile(windowsPath(".release-qa", "windows-unpacked", "PuPu.exe")),
+    signedFile(windowsPath(
+      ".release-qa",
+      "windows-unpacked",
+      "resources",
+      "mcp_runtime",
+      "python",
+      "vcruntime140_1.dll",
+    )),
+    signedFile(windowsPath(
+      ".release-qa",
+      "windows-unpacked",
+      "resources",
+      "mcp_runtime",
+      "python",
+      "vcruntime140.dll",
+    )),
+    signedFile(windowsPath("dist", "PuPu-0.1.10-windows-x64.exe")),
+  ],
+  ...overrides,
+});
+
+test("canonicalizer reproduces and repairs the RC2 PowerShell ordering inversions", () => {
+  const input = evidence();
+  const canonical = canonicalizeWindowsSigningEvidence(input);
+
+  assert.deepEqual(canonical.signed_files.map((file) => file.path), [
+    windowsPath(".release-qa", "windows-unpacked", "PuPu.exe"),
+    windowsPath(".release-qa", "windows-unpacked", "d3dcompiler_47.dll"),
+    windowsPath(".release-qa", "windows-unpacked", "libGLESv2.dll"),
+    windowsPath(
+      ".release-qa",
+      "windows-unpacked",
+      "resources",
+      "mcp_runtime",
+      "python",
+      "vcruntime140.dll",
+    ),
+    windowsPath(
+      ".release-qa",
+      "windows-unpacked",
+      "resources",
+      "mcp_runtime",
+      "python",
+      "vcruntime140_1.dll",
+    ),
+    windowsPath("dist", "PuPu-0.1.10-windows-x64.exe"),
+  ]);
+  assert.deepEqual(canonical.unsigned_payload_exceptions.map((file) => file.path), [
+    windowsPath("resources", "mcp_runtime", "python", "DLLs", "tcl86t.dll"),
+    windowsPath("resources", "mcp_runtime", "python", "DLLs", "tk86t.dll"),
+  ]);
+  assert.equal(
+    input.signed_files[0].path,
+    windowsPath(".release-qa", "windows-unpacked", "d3dcompiler_47.dll"),
+  );
+});
+
+test("canonicalizer rejects duplicate signed paths before artifact admission", () => {
+  const duplicate = signedFile(windowsPath(".release-qa", "windows-unpacked", "PuPu.exe"));
+  assert.throws(
+    () => canonicalizeWindowsSigningEvidence(
+      evidence({ signed_files: [duplicate, duplicate] }),
+    ),
+    /signed_files paths must be unique/,
+  );
+});
+
+test("canonicalizer supports the shared Windows signing qualification schema", () => {
+  const canonical = canonicalizeWindowsSigningEvidence(evidence({
+    schema: "pupu.windows-signing-qualification.v1",
+  }));
+  assert.equal(canonical.schema, "pupu.windows-signing-qualification.v1");
+  assert.equal(canonical.signed_files[0].path, windowsPath(
+    ".release-qa",
+    "windows-unpacked",
+    "PuPu.exe",
+  ));
+});
+
+test("canonicalizer rejects an unsupported evidence schema", () => {
+  assert.throws(
+    () => canonicalizeWindowsSigningEvidence(
+      evidence({ schema: "pupu.windows-signing.future" }),
+    ),
+    /unsupported Windows signing evidence schema/,
+  );
+});
+
+test("CLI rewrites the producer JSON before the composite action publishes it", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "pupu-windows-signing-evidence-"));
+  const evidencePath = path.join(root, "windows-signing-evidence.v1.json");
+  fs.writeFileSync(
+    evidencePath,
+    JSON.stringify(evidence(), null, 2) + String.fromCharCode(10),
+    "utf8",
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [CLI, "--evidence", evidencePath],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const canonical = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+  assert.equal(
+    canonical.signed_files[0].path,
+    windowsPath(".release-qa", "windows-unpacked", "PuPu.exe"),
+  );
+});

--- a/scripts/release-qa/windows-signing-parity.test.mjs
+++ b/scripts/release-qa/windows-signing-parity.test.mjs
@@ -38,6 +38,13 @@ const assertSharedActionContract = (action) => {
   assert.match(action, /signable_payload_file_count/);
   assert.match(action, /signer_subject/);
   assert.match(action, /signer_thumbprint/);
+  assert.match(action, /canonicalize-windows-signing-evidence\.mjs/);
+  assert.match(action, /--evidence "\$env:EVIDENCE_OUTPUT"/);
+  assert.ok(
+    action.indexOf("Set-Content -LiteralPath $env:EVIDENCE_OUTPUT") <
+      action.indexOf("canonicalize-windows-signing-evidence.mjs"),
+    "Windows signing evidence must be canonicalized only after the producer writes it",
+  );
   assert.equal(
     count(action, /uses: azure\/artifact-signing-action@v2/g),
     2,


### PR DESCRIPTION
## Summary

- canonicalize Windows signing evidence with the same UTF-8 byte ordering required by the strict candidate validator
- reject duplicate or malformed signing evidence paths before upload
- apply the shared canonicalizer to formal packaging, signing qualification, and restart-update callers
- add regression coverage for the exact v0.1.10-rc.2 hosted ordering inversions

## Testing

- exact RC2 hosted evidence: raw 37-path document rejected, canonicalized document accepted by the unchanged strict validator
- targeted release tests: 17/17
- full Release QA unit suite: 171/171
- long-run harness: 62/62
- all 22 GitHub Actions YAML files passed strict unique-key parsing
- git diff checks passed
- GitNexus detect-changes against origin/main: LOW, 0 affected processes

## Release handling

- v0.1.10-rc.2 remains immutable
- after merge, the next hosted proof will use a new v0.1.10-rc.3 tag

## Legal

- [x] I have the right to submit this contribution.
- [x] I have read docs/CLA.md and agree that this contribution may be used, relicensed, and commercialized under the terms described there.