### PR TITLE
fix: harden release provenance verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23481,9 +23481,9 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "extract-zip": "2.0.1"
   },
   "overrides": {
-    "shell-quote": "1.9.0"
+    "shell-quote": "1.9.0",
+    "websocket-driver": "0.7.5"
   }
 }

--- a/scripts/release-qa/verify-actions-run-provenance.mjs
+++ b/scripts/release-qa/verify-actions-run-provenance.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -50,8 +49,9 @@ export function assertGithubActionsRunProvenance({ run, runId, tag, commit, work
   if (run.head_branch !== expectedTag) {
     throw new Error("Actions run head branch does not match the release tag");
   }
-  if (typeof run.path !== "string" || !run.path.startsWith(`${expectedWorkflowPath}@`)) {
-    throw new Error(`Actions run workflow path must start with ${expectedWorkflowPath}@`);
+  const actualWorkflowPath = typeof run.path === "string" ? run.path.split("@", 1)[0] : "";
+  if (actualWorkflowPath !== expectedWorkflowPath) {
+    throw new Error(`Actions run workflow path must equal ${expectedWorkflowPath}`);
   }
   return run;
 }
@@ -70,9 +70,18 @@ function parseArgs(argv) {
   return args;
 }
 
-function main() {
+async function readStdin() {
+  process.stdin.setEncoding("utf8");
+  let input = "";
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  return input;
+}
+
+async function main() {
   const args = parseArgs(process.argv.slice(2));
-  const run = JSON.parse(fs.readFileSync(0, "utf8"));
+  const run = JSON.parse(await readStdin());
   assertGithubActionsRunProvenance({
     run,
     runId: args["run-id"] || "",
@@ -84,10 +93,8 @@ function main() {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  try {
-    main();
-  } catch (error) {
+  main().catch((error) => {
     console.error(`[release-provenance] ${error.message || String(error)}`);
-    process.exit(1);
-  }
+    process.exitCode = 1;
+  });
 }

--- a/scripts/release-qa/verify-actions-run-provenance.test.mjs
+++ b/scripts/release-qa/verify-actions-run-provenance.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { assertGithubActionsRunProvenance } from "./verify-actions-run-provenance.mjs";
 
@@ -7,6 +9,7 @@ const RUN_ID = "554433";
 const TAG = "v0.1.10";
 const COMMIT = "a".repeat(40);
 const WORKFLOW = ".github/workflows/release-qa.yml";
+const CLI_PATH = fileURLToPath(new URL("./verify-actions-run-provenance.mjs", import.meta.url));
 
 const validRun = () => ({
   id: Number(RUN_ID),
@@ -25,8 +28,38 @@ const assertValid = (run) => assertGithubActionsRunProvenance({
   workflowPath: WORKFLOW,
 });
 
+const runCli = (run) => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [
+    CLI_PATH,
+    "--run-id", RUN_ID,
+    "--tag", TAG,
+    "--commit", COMMIT,
+    "--workflow-path", WORKFLOW,
+  ], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.once("error", reject);
+  child.once("close", (code) => resolve({ code, stdout, stderr }));
+  child.stdin.end(JSON.stringify(run));
+});
+
 test("Actions run provenance binds the exact successful dispatched workflow to the tag commit", () => {
   assert.equal(assertValid(validRun()).id, Number(RUN_ID));
+  const runWithoutRefSuffix = validRun();
+  runWithoutRefSuffix.path = WORKFLOW;
+  assert.equal(assertValid(runWithoutRefSuffix).id, Number(RUN_ID));
+});
+
+test("Actions run provenance CLI reads a piped run response under Node 24", async () => {
+  const result = await runCli(validRun());
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /verified Actions run 554433/);
 });
 
 test("Actions run provenance rejects a mismatched identity, result, event, tag, commit, or workflow", () => {


### PR DESCRIPTION
## Summary

- read GitHub Actions run JSON from piped stdin asynchronously under Node 24
- accept both current plain workflow paths and legacy path@ref responses while preserving exact workflow identity checks
- add a real CLI pipe regression test

## Evidence

- exact provenance replay against candidate run 33230930812 passed
- npm run test:release-qa: 172 release QA tests + 62 long-run harness tests passed

## Branch note

This promotion also contains #238, which was already merged into dev before this release-flow fix.