### PR TITLE
fix: make bootstrap legacy verification Node 24 safe

### DIFF
--- a/.github/workflows/release-qualification.yml
+++ b/.github/workflows/release-qualification.yml
@@ -116,7 +116,9 @@ jobs:
         run: |
           git fetch --no-tags origin "refs/tags/$FROM_TAG:refs/tags/$FROM_TAG"
           FROM_COMMIT="$(git rev-list -n 1 "$FROM_TAG")"
-          FROM_VERSION="$(git show "$FROM_TAG:package.json" | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version')"
+          FROM_PACKAGE_JSON="$RUNNER_TEMP/from-package.json"
+          git show "$FROM_TAG:package.json" > "$FROM_PACKAGE_JSON"
+          FROM_VERSION="$(FROM_PACKAGE_JSON="$FROM_PACKAGE_JSON" node -p 'require(process.env.FROM_PACKAGE_JSON).version')"
           node scripts/release-qa/validate-update-fixture-source.mjs \
             --candidate-dir candidate \
             --from-tag "$FROM_TAG" \

--- a/scripts/release-qa/validate-legacy-release-gap.mjs
+++ b/scripts/release-qa/validate-legacy-release-gap.mjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 
@@ -24,14 +23,25 @@ const parseArgs = (argv) => {
   return args;
 };
 
-try {
+const readStdin = async () => {
+  process.stdin.setEncoding("utf8");
+  let input = "";
+  for await (const chunk of process.stdin) {
+    input += chunk;
+  }
+  return input;
+};
+
+const main = async () => {
   const args = parseArgs(process.argv.slice(2));
-  const apiRelease = JSON.parse(fs.readFileSync(0, "utf8"));
+  const apiRelease = JSON.parse(await readStdin());
   const policy = readReleaseBootstrapPolicy(path.resolve(args.policy));
   const projection = projectLegacyReleaseApi(apiRelease, policy, args["legacy-tag-commit"]);
   writeJson(path.resolve(args.out), projection);
   console.log(`[release-bootstrap] verified legacy gap for ${projection.release.tag}`);
-} catch (error) {
+};
+
+main().catch((error) => {
   console.error(`[release-bootstrap] ${error.message || String(error)}`);
-  process.exit(1);
-}
+  process.exitCode = 1;
+});

--- a/scripts/release-qa/validate-legacy-release-gap.test.mjs
+++ b/scripts/release-qa/validate-legacy-release-gap.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { readReleaseBootstrapPolicy } from "./release-bootstrap-policy.mjs";
+
+const ROOT = fileURLToPath(new URL("../../", import.meta.url));
+const CLI_PATH = fileURLToPath(new URL("./validate-legacy-release-gap.mjs", import.meta.url));
+const POLICY_PATH = path.join(ROOT, "contracts/release/release-bootstrap-policy.v1.json");
+const policy = readReleaseBootstrapPolicy(POLICY_PATH);
+
+const validApiRelease = () => ({
+  id: policy.legacy_release.release_id,
+  tag_name: policy.legacy_release.tag,
+  draft: policy.legacy_release.draft,
+  prerelease: policy.legacy_release.prerelease,
+  assets: policy.legacy_release.assets.map((asset) => ({ ...asset })),
+});
+
+const runCli = ({ apiRelease, outputPath }) => new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, [
+    CLI_PATH,
+    "--policy", POLICY_PATH,
+    "--legacy-tag-commit", policy.legacy_release.tag_commit,
+    "--out", outputPath,
+  ], {
+    cwd: ROOT,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.once("error", reject);
+  child.once("close", (code) => resolve({ code, stdout, stderr }));
+  child.stdin.end(JSON.stringify(apiRelease));
+});
+
+test("legacy release gap CLI reads a piped GitHub response under Node 24", async (t) => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "pupu-legacy-gap-"));
+  t.after(() => fs.rmSync(outputDir, { recursive: true, force: true }));
+  const outputPath = path.join(outputDir, "legacy-release-projection.v1.json");
+
+  const result = await runCli({ apiRelease: validApiRelease(), outputPath });
+
+  assert.equal(result.code, 0, result.stderr);
+  assert.match(result.stdout, /verified legacy gap for v0\.1\.9/);
+  const projection = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+  assert.deepEqual(projection.release, policy.legacy_release);
+});


### PR DESCRIPTION
## Summary

- stream the GitHub v0.1.9 Release response asynchronously instead of synchronously reading fd 0
- add a real CLI pipe regression test for the frozen legacy projection
- remove the same Node 24 stdin hazard from the future N-1 update qualification path

## Evidence

- real GitHub v0.1.9 Release API projection matched the frozen tag, commit, release ID, assets, sizes, and SHA-256 digests
- repository scan found no remaining readFileSync(0) release paths
- npm run test:release-qa: 175 release QA tests + 62 long-run harness tests passed
- staged GitNexus impact: LOW (3 files, 4 symbols)