### PR TITLE
fix: allow Linux installed qualification in CI

### DIFF
--- a/scripts/release-qa/installed-package-qualification.mjs
+++ b/scripts/release-qa/installed-package-qualification.mjs
@@ -131,6 +131,13 @@ const allocateLoopbackPort = () => new Promise((resolve, reject) => {
   });
 });
 
+export const buildInstalledLaunchArguments = ({ debugPort, userData, platform = process.platform }) => [
+  `--remote-debugging-port=${debugPort}`,
+  `--user-data-dir=${userData}`,
+  ...(platform === "darwin" ? ["--use-mock-keychain"] : []),
+  ...(platform === "linux" ? ["--no-sandbox"] : []),
+];
+
 const parsePosixProcessTable = (source) => String(source || "")
   .split("\n")
   .map((line) => line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/))
@@ -400,11 +407,7 @@ const launchInstalledApplication = async ({ installed, tempRoot }) => {
     NODE_ENV: "production",
     PUPU_TEST_API_DISABLE: "1",
   });
-  const args = [
-    `--remote-debugging-port=${debugPort}`,
-    `--user-data-dir=${userData}`,
-    ...(process.platform === "darwin" ? ["--use-mock-keychain"] : []),
-  ];
+  const args = buildInstalledLaunchArguments({ debugPort, userData });
   const child = spawn(installed.executablePath, args, {
     cwd: installed.launchCwd,
     env: environment,

--- a/scripts/release-qa/installed-package-qualification.test.mjs
+++ b/scripts/release-qa/installed-package-qualification.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { validateInstalledPackageQualificationReport } from "./installed-package-qualification.mjs";
+import {
+  buildInstalledLaunchArguments,
+  validateInstalledPackageQualificationReport,
+} from "./installed-package-qualification.mjs";
 
 const digest = (letter) => `sha256:${letter.repeat(64)}`;
 const fingerprint = "f".repeat(64);
@@ -48,6 +51,40 @@ const validateReport = (report, targetId) => validateInstalledPackageQualificati
   manifest: manifestFor(targetId, report.package_forms),
   targetId,
   manifestDigest: digest("e"),
+});
+
+test("installed qualification disables the Electron sandbox only for Linux CI launches", () => {
+  const linux = buildInstalledLaunchArguments({
+    debugPort: 9222,
+    userData: "/tmp/pupu-user-data",
+    platform: "linux",
+  });
+  assert.deepEqual(linux, [
+    "--remote-debugging-port=9222",
+    "--user-data-dir=/tmp/pupu-user-data",
+    "--no-sandbox",
+  ]);
+
+  const macos = buildInstalledLaunchArguments({
+    debugPort: 9223,
+    userData: "/tmp/pupu-macos-user-data",
+    platform: "darwin",
+  });
+  assert.deepEqual(macos, [
+    "--remote-debugging-port=9223",
+    "--user-data-dir=/tmp/pupu-macos-user-data",
+    "--use-mock-keychain",
+  ]);
+
+  const windows = buildInstalledLaunchArguments({
+    debugPort: 9224,
+    userData: "C:\\pupu-user-data",
+    platform: "win32",
+  });
+  assert.deepEqual(windows, [
+    "--remote-debugging-port=9224",
+    "--user-data-dir=C:\\pupu-user-data",
+  ]);
 });
 
 test("installed qualification accepts the exact package forms for each target", () => {


### PR DESCRIPTION
## Summary

- add a platform-specific installed-app launch argument builder
- pass `--no-sandbox` only on Linux qualification runners, where AppImage/DEB extraction cannot retain a root-owned mode-4755 SUID helper
- keep macOS mock-keychain and Windows launch arguments unchanged
- add exact positive/negative platform argument coverage

## Evidence

- `npm run test:release-qa`: PASS — 176 Release QA tests + 62 long-run harness tests
- targeted installed-package qualification tests: PASS — 5/5
- `git diff --check`: PASS

## Scope and risk

This changes only the non-publishing installed-package qualification launcher for #218. It does not change packaged application defaults or production installer behavior. GitNexus reports one direct caller; the change reaches the full installed qualification gate, so the hosted Linux AppImage + DEB run remains the required deployed-artifact proof.

Refs #218