### PR TITLE
fix: terminate Linux qualification process group

### DIFF
--- a/scripts/release-qa/installed-package-qualification.mjs
+++ b/scripts/release-qa/installed-package-qualification.mjs
@@ -138,6 +138,14 @@ export const buildInstalledLaunchArguments = ({ debugPort, userData, platform = 
   ...(platform === "linux" ? ["--no-sandbox"] : []),
 ];
 
+export const buildInstalledProcessControl = ({ platform = process.platform, pid = null } = {}) => {
+  const processGroup = platform === "linux";
+  return {
+    detached: processGroup,
+    shutdownPid: pid === null ? null : (processGroup ? -pid : pid),
+  };
+};
+
 const parsePosixProcessTable = (source) => String(source || "")
   .split("\n")
   .map((line) => line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/))
@@ -408,8 +416,10 @@ const launchInstalledApplication = async ({ installed, tempRoot }) => {
     PUPU_TEST_API_DISABLE: "1",
   });
   const args = buildInstalledLaunchArguments({ debugPort, userData });
+  const processControl = buildInstalledProcessControl();
   const child = spawn(installed.executablePath, args, {
     cwd: installed.launchCwd,
+    detached: processControl.detached,
     env: environment,
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -452,7 +462,7 @@ const launchInstalledApplication = async ({ installed, tempRoot }) => {
       return sidecar || null;
     }, 60_000, "bundled Sidecar descendant");
 
-    installed.close(child.pid);
+    installed.close(buildInstalledProcessControl({ pid: child.pid }).shutdownPid);
     await waitFor(() => !processAlive(child.pid), 15_000, "controlled installed-app shutdown");
     await waitFor(() => {
       const rows = readProcessTable();

--- a/scripts/release-qa/installed-package-qualification.test.mjs
+++ b/scripts/release-qa/installed-package-qualification.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildInstalledLaunchArguments,
+  buildInstalledProcessControl,
   validateInstalledPackageQualificationReport,
 } from "./installed-package-qualification.mjs";
 
@@ -85,6 +86,21 @@ test("installed qualification disables the Electron sandbox only for Linux CI la
     "--remote-debugging-port=9224",
     "--user-data-dir=C:\\pupu-user-data",
   ]);
+});
+
+test("installed qualification shuts down the complete Linux process group", () => {
+  assert.deepEqual(
+    buildInstalledProcessControl({ platform: "linux", pid: 4242 }),
+    { detached: true, shutdownPid: -4242 },
+  );
+  assert.deepEqual(
+    buildInstalledProcessControl({ platform: "darwin", pid: 4242 }),
+    { detached: false, shutdownPid: 4242 },
+  );
+  assert.deepEqual(
+    buildInstalledProcessControl({ platform: "win32", pid: 4242 }),
+    { detached: false, shutdownPid: 4242 },
+  );
 });
 
 test("installed qualification accepts the exact package forms for each target", () => {


### PR DESCRIPTION
## Summary

- launch Linux installed-package qualification candidates as their own POSIX process group
- send the existing SIGTERM shutdown request to the complete Linux group so AppImage children cannot outlive the wrapper
- preserve macOS AppleScript shutdown and Windows CloseMainWindow behavior
- keep the final candidate-process cleanup assertion fail-closed

## Failure evidence

Bootstrap run 33267474021 passed macOS arm64/x64 and Windows x64, then Linux failed with `installed candidate process cleanup timed out`. The preceding renderer and bundled-Sidecar probes completed; the AppImage wrapper exited while reparented Electron/Sidecar processes remained.

## Verification

- targeted installed qualification tests: PASS — 6/6
- `npm run test:release-qa`: PASS — 177 Release QA tests + 62 long-run harness tests
- `git diff --check`: PASS

## Scope and risk

This only changes the non-publishing installed-package qualification launcher for #218. GitNexus reports one direct caller. The full hosted Linux AppImage + DEB qualification remains the required deployed-artifact proof.

Refs #218