### PR TITLE
fix: clean residual installed candidate processes

### DIFF
--- a/scripts/release-qa/installed-package-qualification.mjs
+++ b/scripts/release-qa/installed-package-qualification.mjs
@@ -221,6 +221,24 @@ const terminateProcesses = async (pids) => {
 
 const normalizePath = (value) => String(value || "").replaceAll("\\", "/").toLowerCase();
 
+export const selectInstalledCleanupPids = ({
+  rows,
+  observedPids,
+  candidateNeedle,
+  currentPid = process.pid,
+}) => {
+  const observed = observedPids instanceof Set
+    ? observedPids
+    : new Set(observedPids || []);
+  const normalizedCandidateNeedle = normalizePath(candidateNeedle);
+  return rows
+    .filter((row) => Number.isSafeInteger(row.pid) && row.pid > 1 && row.pid !== currentPid)
+    .filter((row) => observed.has(row.pid) || (
+      normalizedCandidateNeedle && normalizePath(row.command).includes(normalizedCandidateNeedle)
+    ))
+    .map((row) => row.pid);
+};
+
 const assertSnapshot = (asarPath) => {
   const bytes = Buffer.from(asar.extractFile(asarPath, "build/build_feature_flags.json"));
   const snapshot = JSON.parse(bytes.toString("utf8"));
@@ -464,10 +482,25 @@ const launchInstalledApplication = async ({ installed, tempRoot }) => {
 
     installed.close(buildInstalledProcessControl({ pid: child.pid }).shutdownPid);
     await waitFor(() => !processAlive(child.pid), 15_000, "controlled installed-app shutdown");
+    const cleanupRows = readProcessTable();
+    const cleanupPids = selectInstalledCleanupPids({
+      rows: cleanupRows,
+      observedPids,
+      candidateNeedle,
+    });
+    if (cleanupPids.length > 0) {
+      console.log(
+        `[release-qualification] terminating residual installed candidate processes: ${cleanupPids.join(",")}`,
+      );
+      await terminateProcesses(cleanupPids);
+    }
     await waitFor(() => {
       const rows = readProcessTable();
-      return !rows.some((row) => observedPids.has(row.pid) ||
-        normalizePath(row.command).includes(candidateNeedle));
+      return selectInstalledCleanupPids({
+        rows,
+        observedPids,
+        candidateNeedle,
+      }).length === 0;
     }, 15_000, "installed candidate process cleanup");
     return {
       executed_tests: 4,
@@ -479,7 +512,12 @@ const launchInstalledApplication = async ({ installed, tempRoot }) => {
   } finally {
     await browser?.close().catch(() => {});
     const rows = readProcessTable();
-    await terminateProcesses([child.pid, ...observedPids, ...descendantPids(rows, child.pid)]);
+    await terminateProcesses([
+      child.pid,
+      ...observedPids,
+      ...descendantPids(rows, child.pid),
+      ...selectInstalledCleanupPids({ rows, observedPids, candidateNeedle }),
+    ]);
   }
 };
 

--- a/scripts/release-qa/installed-package-qualification.test.mjs
+++ b/scripts/release-qa/installed-package-qualification.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildInstalledLaunchArguments,
   buildInstalledProcessControl,
+  selectInstalledCleanupPids,
   validateInstalledPackageQualificationReport,
 } from "./installed-package-qualification.mjs";
 
@@ -100,6 +101,34 @@ test("installed qualification shuts down the complete Linux process group", () =
   assert.deepEqual(
     buildInstalledProcessControl({ platform: "win32", pid: 4242 }),
     { detached: false, shutdownPid: 4242 },
+  );
+});
+
+test("installed qualification cleans observed and candidate-owned residual processes", () => {
+  const rows = [
+    { pid: 100, ppid: 1, command: "/opt/pupu/PuPu.exe --type=renderer" },
+    { pid: 101, ppid: 1, command: "/usr/bin/unchain-server" },
+    { pid: 102, ppid: 1, command: "/opt/other/worker" },
+    { pid: 103, ppid: 1, command: "C:\\PUPU-INSTALLED\\PuPu.exe --type=gpu-process" },
+    { pid: 104, ppid: 1, command: "/opt/pupu/PuPu.exe" },
+  ];
+  assert.deepEqual(
+    selectInstalledCleanupPids({
+      rows,
+      observedPids: new Set([101, 102]),
+      candidateNeedle: "/opt/pupu",
+      currentPid: 104,
+    }),
+    [100, 101, 102],
+  );
+  assert.deepEqual(
+    selectInstalledCleanupPids({
+      rows,
+      observedPids: [],
+      candidateNeedle: "c:/pupu-installed",
+      currentPid: 999,
+    }),
+    [103],
   );
 });
 


### PR DESCRIPTION
## Summary
- terminate observed and candidate-owned residual processes after controlled app shutdown
- keep strict zero-residual verification and the existing emergency cleanup backstop
- cover POSIX and Windows path matching with focused tests

## Validation
- `node --test scripts/release-qa/installed-package-qualification.test.mjs` (7/7)
- `npm run test:release-qa` (178/178 Release QA + 62/62 long-run harness)
- `git diff --check`
- GitNexus impact: LOW; one direct caller in the installed-package qualification chain