### PR TITLE
fix: shut down Linux installed candidate gracefully

### DIFF
--- a/scripts/release-qa/installed-package-qualification.mjs
+++ b/scripts/release-qa/installed-package-qualification.mjs
@@ -138,13 +138,10 @@ export const buildInstalledLaunchArguments = ({ debugPort, userData, platform = 
   ...(platform === "linux" ? ["--no-sandbox"] : []),
 ];
 
-export const buildInstalledProcessControl = ({ platform = process.platform, pid = null } = {}) => {
-  const processGroup = platform === "linux";
-  return {
-    detached: processGroup,
-    shutdownPid: pid === null ? null : (processGroup ? -pid : pid),
-  };
-};
+export const buildInstalledProcessControl = ({ pid = null } = {}) => ({
+  detached: false,
+  shutdownPid: pid,
+});
 
 const parsePosixProcessTable = (source) => String(source || "")
   .split("\n")

--- a/scripts/release-qa/installed-package-qualification.test.mjs
+++ b/scripts/release-qa/installed-package-qualification.test.mjs
@@ -89,10 +89,10 @@ test("installed qualification disables the Electron sandbox only for Linux CI la
   ]);
 });
 
-test("installed qualification shuts down the complete Linux process group", () => {
+test("installed qualification shuts down the main process before cleaning residuals", () => {
   assert.deepEqual(
     buildInstalledProcessControl({ platform: "linux", pid: 4242 }),
-    { detached: true, shutdownPid: -4242 },
+    { detached: false, shutdownPid: 4242 },
   );
   assert.deepEqual(
     buildInstalledProcessControl({ platform: "darwin", pid: 4242 }),


### PR DESCRIPTION
## Summary

- stop terminating the entire Linux process group during installed-package qualification
- request graceful shutdown from the Electron main process only
- retain candidate-owned residual process cleanup after the main process exits

## Failure evidence

Bootstrap run 33282613843 passed Windows x64 and both macOS targets, but the Linux `.deb` form timed out during controlled main-process shutdown after the AppImage form completed.

## Validation

- `node --test scripts/release-qa/installed-package-qualification.test.mjs` (7/7)
- `npm run test:release-qa` (178/178 Release QA; 62/62 long-run harness)
- GitNexus staged change analysis: low risk, 2 changed symbols

Related: #218