### PR TITLE
fix: retry Windows qualification temp cleanup

### DIFF
--- a/scripts/release-qa/installed-package-qualification.mjs
+++ b/scripts/release-qa/installed-package-qualification.mjs
@@ -143,6 +143,16 @@ export const buildInstalledProcessControl = ({ pid = null } = {}) => ({
   shutdownPid: pid,
 });
 
+export const removeInstalledQualificationTempRoot = (
+  tempRoot,
+  { remove = fs.rmSync } = {},
+) => remove(tempRoot, {
+  recursive: true,
+  force: true,
+  maxRetries: 20,
+  retryDelay: 100,
+});
+
 const parsePosixProcessTable = (source) => String(source || "")
   .split("\n")
   .map((line) => line.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/))
@@ -663,7 +673,7 @@ export async function runInstalledPackageQualification({ candidateDir, targetId 
       package_forms: packageForms,
     }, { manifest, manifestDigest: manifest.manifest_digest, targetId });
   } finally {
-    fs.rmSync(tempRoot, { recursive: true, force: true });
+    removeInstalledQualificationTempRoot(tempRoot);
   }
 }
 

--- a/scripts/release-qa/installed-package-qualification.test.mjs
+++ b/scripts/release-qa/installed-package-qualification.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildInstalledLaunchArguments,
   buildInstalledProcessControl,
+  removeInstalledQualificationTempRoot,
   selectInstalledCleanupPids,
   validateInstalledPackageQualificationReport,
 } from "./installed-package-qualification.mjs";
@@ -101,6 +102,32 @@ test("installed qualification shuts down the main process before cleaning residu
   assert.deepEqual(
     buildInstalledProcessControl({ platform: "win32", pid: 4242 }),
     { detached: false, shutdownPid: 4242 },
+  );
+});
+
+test("installed qualification configures bounded temp cleanup retries without hiding permanent errors", () => {
+  let observed = null;
+  removeInstalledQualificationTempRoot("C:\\qualification-temp", {
+    remove: (target, options) => {
+      observed = { target, options };
+    },
+  });
+  assert.deepEqual(observed, {
+    target: "C:\\qualification-temp",
+    options: {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 100,
+    },
+  });
+
+  const permanent = Object.assign(new Error("permission denied"), { code: "EACCES" });
+  assert.throws(
+    () => removeInstalledQualificationTempRoot("C:\\qualification-temp", {
+      remove: () => { throw permanent; },
+    }),
+    permanent,
   );
 });
 


### PR DESCRIPTION
## Summary
- retry recursive qualification temp cleanup to tolerate transient Windows ENOTEMPTY/EBUSY/EPERM conditions
- keep cleanup fail-closed after the bounded retry budget
- add regression coverage for retry configuration and permanent errors

## Evidence
- Windows bootstrap failure: Actions run 33288223888, job 99197918347
- targeted installed-package qualification tests: 8/8
- release QA unit tests: 179/179
- long-run harness: 62/62
- GitNexus isolated staged analysis: LOW risk, 2 files, 0 affected execution flows

Related: #218