### PR TITLE
Fix context usage after changing the Ollama window

### DIFF
--- a/docs/data-models/model-and-toolkit-catalog.md
+++ b/docs/data-models/model-and-toolkit-catalog.md
@@ -255,6 +255,14 @@ Context Usage ring reads the same budget, so it follows the pick immediately. Un
 `allowed_payload_keys` do not list it (it is a native Ollama option), and
 rejects anything that is not a positive integer.
 
+The composer occupancy uses the latest reported input-token count divided by
+the currently selected window (or the declared default), capped by the model's
+maximum when known. It recomputes when the selection changes, even before another
+message is sent; it does not estimate the next prompt. The mini app's current
+readout and composition bar use that same capacity. Explicitly selecting a
+historical call, opening a message's historical details, or viewing the run
+summary preserves the recorded call data and window (#280).
+
 **Why an explicit value.** Ollama's own default depends on the machine, not the
 model: 4k context under 24 GiB of VRAM, 32k between 24 and 48 GiB, 256k above
 (Ollama docs, "Context length"). When the prompt is longer than the daemon's

--- a/docs/implementation/ticket-280.md
+++ b/docs/implementation/ticket-280.md
@@ -1,0 +1,71 @@
+# Ticket #280 — selected Ollama context window usage
+
+Ticket: https://github.com/haoxiang-xu/PuPu/issues/280
+Release: #203 (v0.1.11)
+Workspace: /Users/red/Desktop/GITRepo/pupu-280
+Branch: codex/ticket-280-context-window-usage
+Base: remote dev at e8b394880c2841eb728af9754e03fdde0a84f87e
+
+## Goal and reproduction
+
+With 8192 input tokens and a catalog maximum of 131072, change the selected Ollama window from 32768 to 65536. Current code leaves pressure at 6.25%; the composer should show 25% then 12.5%. This is the last observed input measured against the current configured capacity, not an estimate of the next prompt.
+
+`ChatInterface.contextUsageView` currently depends only on messages/capabilities and calls `selectContextWindowTokens`, which reads only the catalog maximum. The request path already sends `selectedContextWindow` as `options.contextWindow`; the sidecar uses the selection or declared default, capped by the catalog maximum. No request or backend changes are required. The shared composition panel currently mixes usage pressure with the recorded call window in its headline/bar.
+
+## Settled implementation decisions
+
+- Preserve the existing maximum-only selector for historical/general callers. Add a renderer helper for the active composer window, with `{modelId, selectedContextWindow}` options.
+- Apply selected/default policy only to built-in `ollama:` model IDs. A valid positive safe integer selection wins, then the catalog's valid `default_context_window_tokens`; cap either by a valid catalog maximum. If neither selection nor declared default is available, return null. Other providers, including custom Ollama protocol providers, keep the existing catalog-maximum behavior.
+- Chat usage recomputation must depend on selection and selected model ID as well as messages/capabilities. Character chats retain their existing behavior, since the request path does not send their context selection.
+- Preserve last reported input-token accounting. No token estimation, sum of calls, receipt mutation, persistence change, or daemon capability/memory-policy work (#228/#229/#234).
+- In the mini app's default current-call pane, use a transient view with the same denominator as the supplied usage view for the headline readout and composition bar. Only overlay when the call's provider/model and input total match the usage view; no overlay on explicitly selected historical calls, aggregate scope, or the historical modal (which supplies no usage view). Preserve the underlying bundle and composition quality/category shares.
+- UI inventory: existing window slider, progress ring, shared composition headline/bar and call picker. This is a value-calculation bug fix; no new controls, layout, styles, or visual design decisions.
+
+## Acceptance and boundary assessment
+
+- AC-001: Selecting 32K then 64K with unchanged usage changes capacity/pressure immediately, without another request.
+- AC-002: Declared default, maximum cap, missing maximum, missing/invalid values and cloud/custom-provider isolation are covered by service tests.
+- AC-003: The current mini app headline percentage, token/window readout and composition bar agree after rerender; raw bundle stays unchanged.
+- AC-004: Explicit historical-call selection and historical modal retain recorded windows and percentages; aggregate scope remains recorded.
+- Cross-boundary gate: NOT_APPLICABLE. Only renderer-local derived values and React dependencies change. Existing storage records, read/write functions, IPC/HTTP/provider payloads, closed schemas, runtime code and deployment artifacts are untouched. Historical data is read into a temporary UI view, never projected to compiler/provider wire. No runtime retry/resume behavior changes; wheel-pair rollout qualification is outside this renderer-only implementation.
+- UI sequence: same messages -> change selected window -> rerender -> inspect historical call -> return/reopen current view. AC-001/003/004 cover this non-persistent display sequence.
+
+## Execution slices and supervision
+
+Partially suitable for a lower-cost implementation worker. Root cause, effective-window policy and observable tests are settled for the service/chat slice; panel consistency and historical-call isolation remain with the strong parent for direct implementation and integration review.
+
+Worker: gpt-5.6-sol, high reasoning. Strong reviewer: parent GPT-6 agent.
+
+Slice 1 (worker, stop after this checkpoint): only `src/SERVICEs/context_usage_v1.js`, its test file, `src/PAGEs/chat/chat.js`, and `src/PAGEs/chat/chat.test.js`. Implement the helper and wiring. Add service edge cases and a chat-level regression that changes the selected window with stable messages/capabilities. Record red-before-green evidence. Do not edit panel files, schemas, storage, backend, or docs. Run required GitNexus impact before every existing symbol edit, warn on HIGH/CRITICAL, corroborate UNKNOWN. No commit/push. Stop and report unexpected interfaces or scope changes.
+
+Parent slice (independent): shared panel transient display projection and regression tests in `context_composition_panel.test.js`; inspect historical modal behavior. Review worker's diff and evidence before integration.
+
+Commands (run from this clone):
+
+```
+CI=true npm test -- --watchAll=false --runInBand --runTestsByPath src/SERVICEs/context_usage_v1.test.js
+CI=true npm test -- --watchAll=false --runInBand --runTestsByPath src/PAGEs/chat/chat.test.js -t 'context window'
+CI=true npm test -- --watchAll=false --runInBand --runTestsByPath src/COMPONENTs/chat-bubble/context-composition/context_composition_panel.test.js src/COMPONENTs/chat-bubble/context-composition/context_composition_modal.test.js src/COMPONENTs/chat-input/components/context_composition_progress.test.js
+```
+
+Dependencies: node_modules symlink uses the existing installed dependency tree; source/tests are rooted in this independent clone. GitNexus index must be this clone's. No product files copied from the original dirty checkout.
+
+## Evidence
+
+Implementation-ready, 2026-09-12. Strong-agent checkpoint accepted after correcting the integration fixture to use canonical same-model Ollama receipt and usage-slice identity, with recomputed receipt hash and bundle digest.
+
+- Clone-local pre-edit impact: selector LOW (contextUsageView -> sharedChatInputProps), derived contextUsageView LOW. ScopePane/ChatInterface JSX callers UNKNOWN, corroborated via source imports/render sites; composer, historical modal and application/chat paths were explicitly reviewed.
+- Red-before-green: chat baseline reported 131072 / 0.0625 for 8192 input instead of the configured default 32768 / 0.25. Parent panel tests failed on old 128K readouts while usage percentage reflected 4K.
+- Final combined command includes all five suites listed above, run together on the final code and canonical Ollama fixture: **5 suites passed, 225 tests passed, 51.105 seconds**. Service 30; full chat 165; panel/modal/progress 30. Logs include a fake/native timer warning but no failed test.
+- AC-001: same messages/catalog, default32K -> callback64K, input8192, pressure25% ->12.5%, no stream request. AC-002: defaults, caps, invalid values, missing maximum and cloud/custom isolation covered. AC-003/004: rerendered headline/readout/bar agree, raw bundle unchanged, explicit history and mismatched model retain recorded evidence; historical modal and aggregate tests pass.
+- Post-edit GitNexus detect-changes --scope all --limit 100 --repo .: 7 tracked files, 19 mapped symbols, 8 affected ChatInterface flows, HIGH. User warned; complete backend result (no partial/truncated warning). CLI presentation itself shows only the first 15 symbols; its formatter confirms this is a display cap. New untracked implementation plan is also reviewed by git status/diff, not counted in that tracked diff.
+- git diff --check passes. Product diff is limited to renderer window resolution, memo dependencies and transient panel values; no persistence, wire, runtime, styles or UI controls changed. Catalog documentation updated.
+- Desktop/daemon live smoke was NOT_RUN; this is development-test evidence, not release acceptance or deployed Ollama qualification. No Python changes, sidecar restart, commit, push, PR or audit.
+
+Issue remains OPEN / In Progress under #203. User-requested close is the next workflow step for PR/audit/cleanup.
+
+## PR preparation — 2026-09-12
+
+The user explicitly requested a PR, authorizing the delivery commit and push for this ticket. Fast-forwarded the independent branch to current remote dev `5c18e8b8f9801cee8a8641d6cffd6948cb728661` without conflicts; no changes to the original workspace. The two newer dev changes concern input palette sizing and attach-panel layout.
+
+Fresh integration verification on that base: the original five suites plus `src/COMPONENTs/chat-input/components/attach_panel.test.js`, run together with `CI=true npm test -- --watchAll=false --runInBand --runTestsByPath ...`: **6 suites passed, 307 tests passed, 52.713 seconds**. Existing timer/React act diagnostics remain in the log, with no test failures. No desktop/daemon live smoke or release acceptance claim. This request creates the PR; it does not merge it, close the issue, invoke the close/audit workflow, or delete this clone.

--- a/src/COMPONENTs/chat-bubble/context-composition/context_composition_panel.js
+++ b/src/COMPONENTs/chat-bubble/context-composition/context_composition_panel.js
@@ -919,54 +919,79 @@ const ScopePane = ({
   onOpenGroup,
   palette,
   t,
-}) => (
-  <div
-    ref={paneRef}
-    id={`context-composition-${scopeId}-panel`}
-    data-testid={`context-composition-pane-${scopeId}`}
-    role="tabpanel"
-    aria-labelledby={`context-composition-${scopeId}-tab`}
-    aria-live="polite"
-    aria-hidden={!active}
-    inert={!active}
-    style={{ flex: "0 0 50%", minWidth: 0, boxSizing: "border-box" }}
-  >
-    {!view.available && usageView && scopeId === "model_call" ? (
-      <UsageOnlyView usage={usageView} palette={palette} t={t} active={active} />
-    ) : view.available ? (
-      <>
-        {scopeId === "model_call" && (
-          <CallPicker
-            calls={view.calls || []}
-            selectedCallKey={selectedCallKey || view.selectedCallKey}
-            onChange={onSelectCall}
+}) => {
+  // The composer measures the latest observed input against its current
+  // capacity. Explicit call selection and the historical modal keep the
+  // recorded window. Never combine accounting from different model calls.
+  const currentUsage =
+    scopeId === "model_call" &&
+    !selectedCallKey &&
+    (!view.available ||
+      (view.call?.provider === usageView?.provider &&
+        view.call?.model === usageView?.model &&
+        view.providerInputTokens === usageView?.inputTokens))
+      ? usageView
+      : null;
+  const displayView =
+    currentUsage?.percentageAvailable === true &&
+    Number.isSafeInteger(currentUsage.contextWindowTokens) &&
+    currentUsage.contextWindowTokens > 0
+      ? {
+          ...view,
+          contextWindowTokens: currentUsage.contextWindowTokens,
+          windowPressure: currentUsage.windowPressure,
+        }
+      : view;
+
+  return (
+    <div
+      ref={paneRef}
+      id={`context-composition-${scopeId}-panel`}
+      data-testid={`context-composition-pane-${scopeId}`}
+      role="tabpanel"
+      aria-labelledby={`context-composition-${scopeId}-tab`}
+      aria-live="polite"
+      aria-hidden={!active}
+      inert={!active}
+      style={{ flex: "0 0 50%", minWidth: 0, boxSizing: "border-box" }}
+    >
+      {!view.available && currentUsage && scopeId === "model_call" ? (
+        <UsageOnlyView usage={currentUsage} palette={palette} t={t} active={active} />
+      ) : view.available ? (
+        <>
+          {scopeId === "model_call" && (
+            <CallPicker
+              calls={view.calls || []}
+              selectedCallKey={selectedCallKey || view.selectedCallKey}
+              onChange={onSelectCall}
+              palette={palette}
+              t={t}
+            />
+          )}
+          <Headline
+            view={displayView}
+            usageView={currentUsage}
             palette={palette}
             t={t}
+            active={active}
           />
-        )}
-        <Headline
-          view={view}
-          usageView={usageView}
-          palette={palette}
-          t={t}
-          active={active}
-        />
-        <CompositionBar view={view} palette={palette} t={t} active={active} />
-        <GroupList
-          view={view}
-          openGroup={openGroup}
-          onOpenGroup={onOpenGroup}
-          palette={palette}
-          t={t}
-          active={active}
-        />
-        <QualityLine view={view} palette={palette} t={t} active={active} />
-      </>
-    ) : (
-      <UnavailableView reason={view.reason} palette={palette} t={t} active={active} />
-    )}
-  </div>
-);
+          <CompositionBar view={displayView} palette={palette} t={t} active={active} />
+          <GroupList
+            view={view}
+            openGroup={openGroup}
+            onOpenGroup={onOpenGroup}
+            palette={palette}
+            t={t}
+            active={active}
+          />
+          <QualityLine view={view} palette={palette} t={t} active={active} />
+        </>
+      ) : (
+        <UnavailableView reason={view.reason} palette={palette} t={t} active={active} />
+      )}
+    </div>
+  );
+};
 
 /**
  * Shared body for both shells — the anchored popover on the attach panel and

--- a/src/COMPONENTs/chat-bubble/context-composition/context_composition_panel.test.js
+++ b/src/COMPONENTs/chat-bubble/context-composition/context_composition_panel.test.js
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { ConfigContext } from "../../../CONTAINERs/config/context";
 import defaultTheme from "../../../BUILTIN_COMPONENTs/theme/default_mini_theme.json";
 import { CONTEXT_COMPOSITION_EXTENSION_KEY } from "../../../SERVICEs/context_composition_v1";
+import { buildContextUsageView, selectContextUsage } from "../../../SERVICEs/context_usage_v1";
 import ContextCompositionPanel, {
   CONTENT_HEIGHT_BUFFER,
   MAX_PANE_VIEWPORT_HEIGHT,
@@ -169,6 +170,77 @@ const renderPanel = async (props = {}) => {
 };
 
 const track = () => screen.getByTestId("context-composition-track");
+
+describe("Current composer window display", () => {
+  test("updates the readout and composition bar with current usage without rewriting the receipt", async () => {
+    const bundle = dualAvailableBundle();
+    const original = JSON.stringify(bundle);
+    const usage = selectContextUsage(bundle);
+    const surface = (windowTokens) => (
+      <ConfigContext.Provider value={{ theme: defaultTheme.dark_mode, onThemeMode: "dark_mode" }}>
+        <ContextCompositionPanel
+          bundle={bundle}
+          usageView={buildContextUsageView(usage, windowTokens)}
+          open
+          palette={palette}
+        />
+      </ConfigContext.Provider>
+    );
+    const { rerender } = render(surface(4000));
+    await act(async () => {});
+    const headline = () => screen.getByTestId("context-composition-headline");
+    const bar = () => within(screen.getByTestId("context-composition-pane-model_call"))
+      .getByRole("img", { name: /Estimated input composition against the context window/i });
+    expect(headline()).toHaveTextContent(/25% full/i);
+    expect(headline()).toHaveTextContent("~1K / 4K Tokens");
+    expect(bar().firstChild).toHaveStyle({ width: "7.5%" });
+
+    rerender(surface(8000));
+    expect(headline()).toHaveTextContent(/13% full/i);
+    expect(headline()).toHaveTextContent("~1K / 8K Tokens");
+    expect(bar().firstChild).toHaveStyle({ width: "3.75%" });
+    expect(JSON.stringify(bundle)).toBe(original);
+
+    // A historical shell has no current-composer usage override.
+    rerender(surface(null));
+    expect(headline()).toHaveTextContent("~1K / 128K Tokens");
+    expect(bar().firstChild).toHaveStyle({ width: "0.25%" });
+    expect(JSON.stringify(bundle)).toBe(original);
+  });
+
+  test("explicit call selection uses that call's recorded pressure and window", async () => {
+    const bundle = twoCallBundle();
+    const latest = bundle.provider_calls[0];
+    const usageView = buildContextUsageView({
+      inputTokens: latest.usage.input.total_tokens,
+      provider: latest.provider.name,
+      model: latest.provider.model,
+    }, 4000);
+    await renderPanel({ bundle, usageView });
+    expect(screen.getByTestId("context-composition-headline"))
+      .toHaveTextContent("~350 / 4K Tokens");
+    fireEvent.click(screen.getByRole("option", { name: /Call 1 · openai/i }));
+    expect(screen.getByTestId("context-composition-headline"))
+      .toHaveTextContent("~1K / 128K Tokens");
+    expect(screen.getByTestId("context-composition-headline"))
+      .toHaveTextContent(/0.8% full/i);
+  });
+
+  test("does not apply another model's accounting to the displayed call", async () => {
+    const bundle = dualAvailableBundle();
+    await renderPanel({
+      bundle,
+      usageView: buildContextUsageView({
+        ...selectContextUsage(bundle),
+        model: "another-model",
+      }, 4000),
+    });
+    expect(screen.getByTestId("context-composition-headline"))
+      .toHaveTextContent(/0.8% full/i);
+    expect(screen.getByTestId("context-composition-headline"))
+      .toHaveTextContent("~1K / 128K Tokens");
+  });
+});
 
 describe("Both scopes stay mounted for the slide", () => {
   test("Context and Summary panes are both in the DOM regardless of which is active", async () => {

--- a/src/PAGEs/chat/chat.js
+++ b/src/PAGEs/chat/chat.js
@@ -51,6 +51,7 @@ import { PUPU_PREFILL_COMPOSER } from "../../SERVICEs/composer_prefill";
 import { selectLatestContextCompositionBundle } from "../../SERVICEs/context_composition_v1";
 import {
   buildContextUsageView,
+  selectActiveContextWindowTokens,
   selectContextWindowTokens,
   selectLatestContextUsage,
 } from "../../SERVICEs/context_usage_v1";
@@ -954,16 +955,26 @@ const ChatInterface = () => {
     [session.messages],
   );
   // Accounting-only pressure. Independent of Context Composition so the
-  // indicator works before any contribution source is instrumented; the window
-  // comes from model capabilities and stays null when the catalog has none.
+  // indicator works before any contribution source is instrumented. Normal
+  // chats use the active composer selection; character chats retain the
+  // catalog-maximum behavior because their request path has no window picker.
   const contextUsageView = useMemo(() => {
     const usage = selectLatestContextUsage(session.messages);
     if (!usage) return null;
-    return buildContextUsageView(
-      usage,
-      selectContextWindowTokens(activeModelCapabilities),
-    );
-  }, [session.messages, activeModelCapabilities]);
+    const windowTokens = session.isCharacterChat
+      ? selectContextWindowTokens(activeModelCapabilities)
+      : selectActiveContextWindowTokens(activeModelCapabilities, {
+          modelId: session.selectedModelId,
+          selectedContextWindow: session.selectedContextWindow,
+        });
+    return buildContextUsageView(usage, windowTokens);
+  }, [
+    session.messages,
+    activeModelCapabilities,
+    session.isCharacterChat,
+    session.selectedModelId,
+    session.selectedContextWindow,
+  ]);
   const {
     containerRef: smoothResizeContainerRef,
     frameStyle: smoothResizeFrameStyle,

--- a/src/PAGEs/chat/chat.test.js
+++ b/src/PAGEs/chat/chat.test.js
@@ -42,6 +42,7 @@ const {
   buildRunBundleV1,
 } = require("../../../electron/tests/fixtures/run_bundle_v1_fixture.cjs");
 const {
+  computeProviderCallReceiptSha256,
   computeRunBundleDigest,
 } = require("../../../electron/shared/run_bundle_v1");
 
@@ -1854,6 +1855,83 @@ describe("ChatInterface stop flow", () => {
     });
     fireEvent.click(screen.getByTestId("send-button"));
 
+    expect(window.unchainAPI.startStreamV2).not.toHaveBeenCalled();
+  });
+
+  test("updates context window pressure when the Ollama selection changes", async () => {
+    const store = getChatsStore();
+    const chatId = store.activeChatId;
+    setChatModel(
+      chatId,
+      { id: "ollama:llama3.2" },
+      { source: "test" },
+    );
+    const bundle = buildRunBundleV1();
+    bundle.provider_calls[0].provider.name = "ollama";
+    bundle.provider_calls[0].provider.model = "llama3.2";
+    bundle.usage_slices[0].provider = "ollama";
+    bundle.usage_slices[0].model = "llama3.2";
+    [
+      bundle.provider_calls[0].usage,
+      bundle.aggregation.direct_usage,
+      bundle.aggregation.all_usage,
+      bundle.usage_slices[0].usage,
+    ].forEach((usage) => {
+      usage.input.uncached_tokens = 7592;
+      usage.input.total_tokens = 8192;
+      usage.total_tokens = 8392;
+    });
+    bundle.evidence.receipt_sha256s = [
+      computeProviderCallReceiptSha256(bundle.provider_calls[0]),
+    ];
+    bundle.bundle_digest = computeRunBundleDigest(bundle);
+    setChatMessages(
+      chatId,
+      [
+        {
+          id: "assistant-context-window",
+          role: "assistant",
+          content: "Measured response",
+          meta: { bundle },
+        },
+      ],
+      { source: "test" },
+    );
+    window.unchainAPI.getModelCatalog.mockResolvedValue({
+      activeModel: "ollama:llama3.2",
+      providers: {
+        openai: [],
+        ollama: ["llama3.2"],
+        anthropic: [],
+      },
+      model_capabilities: {
+        "ollama:llama3.2": {
+          default_context_window_tokens: 32768,
+          max_context_window_tokens: 131072,
+        },
+      },
+    });
+
+    renderChat();
+    await waitFor(() => {
+      expect(lastChatInputProps?.contextUsageView).toMatchObject({
+        inputTokens: 8192,
+        contextWindowTokens: 32768,
+        windowPressure: 0.25,
+      });
+    });
+
+    act(() => {
+      lastChatInputProps.onSelectContextWindow(65536);
+    });
+
+    await waitFor(() => {
+      expect(lastChatInputProps?.contextUsageView).toMatchObject({
+        inputTokens: 8192,
+        contextWindowTokens: 65536,
+        windowPressure: 0.125,
+      });
+    });
     expect(window.unchainAPI.startStreamV2).not.toHaveBeenCalled();
   });
 

--- a/src/SERVICEs/context_usage_v1.js
+++ b/src/SERVICEs/context_usage_v1.js
@@ -85,6 +85,40 @@ export const selectContextWindowTokens = (capabilities) => {
     : null;
 };
 
+/**
+ * Resolve the window currently configured for the composer. Built-in Ollama
+ * models expose a selectable request window; other providers retain the
+ * catalog-maximum denominator used by historical and general callers.
+ */
+export const selectActiveContextWindowTokens = (
+  capabilities,
+  { modelId, selectedContextWindow } = {},
+) => {
+  const normalizedModelId =
+    typeof modelId === "string" ? modelId.trim() : "";
+  const maximum = selectContextWindowTokens(capabilities);
+  if (!normalizedModelId.startsWith("ollama:")) return maximum;
+
+  const selected =
+    typeof selectedContextWindow === "number" &&
+    Number.isSafeInteger(selectedContextWindow) &&
+    selectedContextWindow > 0
+      ? selectedContextWindow
+      : null;
+  const declaredDefault = isObject(capabilities)
+    ? capabilities.default_context_window_tokens
+    : null;
+  const fallback =
+    typeof declaredDefault === "number" &&
+    Number.isSafeInteger(declaredDefault) &&
+    declaredDefault > 0
+      ? declaredDefault
+      : null;
+  const requested = selected ?? fallback;
+  if (requested === null) return null;
+  return maximum === null ? requested : Math.min(requested, maximum);
+};
+
 export const buildContextUsageView = (usage, windowTokens) => {
   if (!isObject(usage) || usage.inputTokens === null) return null;
   const window =

--- a/src/SERVICEs/context_usage_v1.test.js
+++ b/src/SERVICEs/context_usage_v1.test.js
@@ -1,5 +1,6 @@
 import {
   buildContextUsageView,
+  selectActiveContextWindowTokens,
   selectContextUsage,
   selectContextWindowTokens,
   selectLatestContextUsage,
@@ -80,6 +81,127 @@ describe("Context window denominator", () => {
     ["not an object", null],
   ])("rejects %s", (_label, capabilities) => {
     expect(selectContextWindowTokens(capabilities)).toBeNull();
+  });
+
+  describe("active composer window", () => {
+    const ollamaCapabilities = {
+      default_context_window_tokens: 32768,
+      max_context_window_tokens: 131072,
+    };
+
+    test("uses the selected built-in Ollama window before the declared default", () => {
+      expect(
+        selectActiveContextWindowTokens(ollamaCapabilities, {
+          modelId: "ollama:llama3.2",
+          selectedContextWindow: 65536,
+        }),
+      ).toBe(65536);
+    });
+
+    test("uses the declared built-in Ollama default when no selection exists", () => {
+      expect(
+        selectActiveContextWindowTokens(ollamaCapabilities, {
+          modelId: "ollama:llama3.2",
+          selectedContextWindow: null,
+        }),
+      ).toBe(32768);
+    });
+
+    test.each([
+      ["selection", 262144, 32768],
+      ["default", null, 262144],
+    ])("caps a built-in Ollama %s at the catalog maximum", (
+      _label,
+      selectedContextWindow,
+      defaultContextWindow,
+    ) => {
+      expect(
+        selectActiveContextWindowTokens(
+          {
+            default_context_window_tokens: defaultContextWindow,
+            max_context_window_tokens: 131072,
+          },
+          {
+            modelId: "ollama:llama3.2",
+            selectedContextWindow,
+          },
+        ),
+      ).toBe(131072);
+    });
+
+    test.each([
+      ["selection", 65536, null, 65536],
+      ["default", null, 32768, 32768],
+    ])("keeps a valid built-in Ollama %s when the maximum is missing", (
+      _label,
+      selectedContextWindow,
+      defaultContextWindow,
+      expected,
+    ) => {
+      expect(
+        selectActiveContextWindowTokens(
+          { default_context_window_tokens: defaultContextWindow },
+          {
+            modelId: "ollama:llama3.2",
+            selectedContextWindow,
+          },
+        ),
+      ).toBe(expected);
+    });
+
+    test.each([
+      ["zero", 0],
+      ["negative", -1],
+      ["string", "65536"],
+      ["fractional", 65536.5],
+      ["unsafe", Number.MAX_SAFE_INTEGER + 1],
+    ])("ignores an invalid built-in Ollama %s selection", (
+      _label,
+      selectedContextWindow,
+    ) => {
+      expect(
+        selectActiveContextWindowTokens(ollamaCapabilities, {
+          modelId: "ollama:llama3.2",
+          selectedContextWindow,
+        }),
+      ).toBe(32768);
+    });
+
+    test("returns null when built-in Ollama has no valid selection or default", () => {
+      expect(
+        selectActiveContextWindowTokens(
+          { max_context_window_tokens: 131072 },
+          {
+            modelId: "ollama:llama3.2",
+            selectedContextWindow: null,
+          },
+        ),
+      ).toBeNull();
+      expect(
+        selectActiveContextWindowTokens(
+          {
+            default_context_window_tokens: "32768",
+            max_context_window_tokens: 131072,
+          },
+          {
+            modelId: "ollama:llama3.2",
+            selectedContextWindow: 0,
+          },
+        ),
+      ).toBeNull();
+    });
+
+    test.each(["openai:gpt-5", "custom.local:llama3.2", null])(
+      "keeps maximum-only behavior for %s",
+      (modelId) => {
+        expect(
+          selectActiveContextWindowTokens(ollamaCapabilities, {
+            modelId,
+            selectedContextWindow: 65536,
+          }),
+        ).toBe(131072);
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Changing the Ollama context window now immediately recalculates the Context Window mini app against the selected window (or declared default), capped by the model maximum. Its percentage, window readout and composition bar use the same capacity. Historical call details retain their recorded window.

Refs #280. This changes renderer calculations only; provider requests, stored receipts and other providers' window policy are unchanged.

## Testing

- Synced with dev `5c18e8b8`; 6 targeted suites passed, **307 tests passed**, including the full chat and updated attach-panel suites.
- Regression proves unchanged 8192-token usage moves from 25% at 32K to 12.5% at 64K without a new request; covers defaults, caps, unknown maxima and historical details.
- `git diff --check` and GitNexus change analysis completed. Desktop/daemon smoke was not run.

## Legal

- [ ] I have the right to submit this contribution.
- [ ] I have read `docs/CLA.md` and agree that this contribution may be used,
      relicensed, and commercialized under the terms described there.
